### PR TITLE
Fix a typo (secenarios) in callbacks doc

### DIFF
--- a/Source/Docs/help/_posts/2010-05-01-callbacks.markdown
+++ b/Source/Docs/help/_posts/2010-05-01-callbacks.markdown
@@ -79,7 +79,7 @@ Argument callbacks give us slightly more concise code in a style that is more in
 
 ## Callback builder for more complex callbacks
 
-The `Callback` builder lets us create more complex `Do()` secenarios.  We can use `Callback.First()` followed by `Then()`, `ThenThrow()` and `ThenKeepDoing()` to build chains of callbacks. We can also use `Always()` and `AlwaysThrow()` to specify callbacks called every time. Note that a callback set by an `Always()` method will be called even if other callbacks will throw an exception.
+The `Callback` builder lets us create more complex `Do()` scenarios.  We can use `Callback.First()` followed by `Then()`, `ThenThrow()` and `ThenKeepDoing()` to build chains of callbacks. We can also use `Always()` and `AlwaysThrow()` to specify callbacks called every time. Note that a callback set by an `Always()` method will be called even if other callbacks will throw an exception.
 
 {% requiredcode %}
 public interface ISomething { void Something(); }


### PR DESCRIPTION
There is a small typo in the http://nsubstitute.github.io/help/callbacks/ page:

    The `Callback` builder lets us create more complex `Do()` secenarios.

should read

    The `Callback` builder lets us create more complex `Do()` scenarios.